### PR TITLE
Fix dynamic memory malloc typo

### DIFF
--- a/01-dynamic-memory.tex
+++ b/01-dynamic-memory.tex
@@ -30,7 +30,7 @@ Nevertheless, we will study them because
   (2)~they are simple, and
   (3)~similar ideas are used in later lectures.
 If your preferred language is Java,
-  then think of \.{x=(T*)malloc(sizeof(T) * n)} as C's counterpart of \.{x=new T[n]}:
+  then think of \.{x=malloc(sizeof(T) * n)} as C's counterpart of \.{x=new T[n]}:
   that's how we allocate memory for $n$~objects of type~$T$.
 However,
   nothing like \.{free(x)} exists in Java.


### PR DESCRIPTION
From my understanding, the result of `malloc` shouldn't be manually cast in C, since it can be done by the language automatically. Worth noting that the other uses of `malloc` aren't manually cast.

I should be revising but I just had to :)